### PR TITLE
PRST-2562: Add configurable frontend colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ The following are the available command-line flags(excluding above wallet flags)
 | -hcaptcha.secret     | hCaptcha secret                                   |                     |
 | -frontend.logo       | Logo URL to display on the frontend               | /gatewayfm-logo.svg |
 | -frontend.background | Background to display on the frontend             | /background.jpg     |
+| -frontend.primaryColor | Primary accent color (hex)                       | #8950fa             |
+| -frontend.primaryColorLight | Light variant of primary color (hex)        | #eee8ff             |
+| -frontend.primaryColorDark | Dark variant of primary color (hex)          | #161718             |
 | -frontend.type       | Type of Frontend to display (base, redesign)      | base                |
 | -faucet.paidcustomer | Whether the faucet will belong to a paid customer | false               |
 | -wallet.mainnetprovider | Endpoint for Ethereum mainnet JSON-RPC connection |                     |

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -37,6 +37,9 @@ var (
 	mainnetProviderFlag   = flag.String("wallet.mainnetprovider", os.Getenv("MAINNET_WEB3_PROVIDER"), "Endpoint for Ethereum mainnet JSON-RPC connection")
 	minMainnetBalanceFlag = flag.Int64("faucet.minmainnetbalance", 0, "Minimum balance required on mainnet (in Gwei)")
 
+	primaryColorFlag      = flag.String("frontend.primaryColor", "#8950fa", "Primary accent color for the frontend (hex, e.g. #0046FF)")
+	primaryColorLightFlag = flag.String("frontend.primaryColorLight", "#eee8ff", "Light variant of primary color (hex, e.g. #D6E4FF)")
+	primaryColorDarkFlag  = flag.String("frontend.primaryColorDark", "#161718", "Dark variant of primary color (hex, e.g. #001A4D)")
 	frontendTypeFlag = flag.String("frontend.type", "redesign", "Type of frontend to generate. Values enum: 'base', 'redesign'.")
 	paidCustomerFlag = flag.Bool("faucet.paidcustomer", false, "Whether the faucet belongs to the paid customer")
 
@@ -86,6 +89,9 @@ func Execute() {
 		*hcaptchaSecretFlag,
 		*logoFlag,
 		*backgroundFlag,
+		*primaryColorFlag,
+		*primaryColorLightFlag,
+		*primaryColorDarkFlag,
 		*frontendTypeFlag,
 		*paidCustomerFlag,
 		*mainnetProviderFlag,

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -15,6 +15,9 @@ type Config struct {
 	hcaptchaSecret    string
 	logoURL           string
 	backgroundURL     string
+	primaryColor      string
+	primaryColorLight string
+	primaryColorDark  string
 	frontendType      string
 	paidCustomer      bool
 	mainnetProvider   string
@@ -25,7 +28,7 @@ func NewConfig(
 	network, symbol string,
 	httpPort, interval, proxyCount int,
 	payout int64,
-	hcaptchaSiteKey, hcaptchaSecret, logoURL, backgroundURL string,
+	hcaptchaSiteKey, hcaptchaSecret, logoURL, backgroundURL, primaryColor, primaryColorLight, primaryColorDark string,
 	frontendType string,
 	paidCustomer bool,
 	mainnetProvider string,
@@ -42,6 +45,9 @@ func NewConfig(
 		hcaptchaSecret:    hcaptchaSecret,
 		logoURL:           logoURL,
 		backgroundURL:     backgroundURL,
+		primaryColor:      primaryColor,
+		primaryColorLight: primaryColorLight,
+		primaryColorDark:  primaryColorDark,
 		frontendType:      frontendType,
 		paidCustomer:      paidCustomer,
 		mainnetProvider:   mainnetProvider,

--- a/internal/server/dto.go
+++ b/internal/server/dto.go
@@ -28,6 +28,9 @@ type infoResponse struct {
 	HcaptchaSiteKey string `json:"hcaptcha_sitekey,omitempty"`
 	LogoURL         string `json:"logo_url"`
 	BackgroundURL   string `json:"background_url"`
+	PrimaryColor      string `json:"primary_color,omitempty"`
+	PrimaryColorLight string `json:"primary_color_light,omitempty"`
+	PrimaryColorDark  string `json:"primary_color_dark,omitempty"`
 	PaidCustomer    bool   `json:"paid_customer"`
 	FrontendType    string `json:"frontend_type"`
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -123,6 +123,9 @@ func (s *Server) handleInfo() http.HandlerFunc {
 			HcaptchaSiteKey: s.cfg.hcaptchaSiteKey,
 			LogoURL:         s.cfg.logoURL,
 			BackgroundURL:   s.cfg.backgroundURL,
+			PrimaryColor:      s.cfg.primaryColor,
+			PrimaryColorLight: s.cfg.primaryColorLight,
+			PrimaryColorDark:  s.cfg.primaryColorDark,
 			FrontendType:    s.cfg.frontendType,
 			PaidCustomer:    s.cfg.paidCustomer,
 		}, http.StatusOK)

--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + Svelte</title>
+    <title></title>
   </head>
   <body>
     <div id="app"></div>

--- a/web/src/Faucet.svelte
+++ b/web/src/Faucet.svelte
@@ -19,6 +19,9 @@
     hcaptcha_sitekey: '',
     logo_url: '/gatewayfm-logo.svg',
     background_url: 'background.jpg',
+    primary_color: '#8950fa',
+    primary_color_light: '#eee8ff',
+    primary_color_dark: '#161718',
     frontend_type: 'redesign',
     paid_customer: false,
   };
@@ -65,10 +68,6 @@
     hcaptchaLoaded = true;
   };
 
-  $: document.title = `${faucetInfo.symbol} ${capitalize(
-    faucetInfo.network,
-  )} Faucet`;
-
   window.hcaptchaOnLoad = () => {
     hcaptchaLoaded = true;
   };
@@ -76,9 +75,9 @@
   $: baseFrontendType = faucetInfo.frontend_type === 'base';
   $: redesignFrontendType = faucetInfo.frontend_type === 'redesign';
 
-  $: document.title = `${faucetInfo.symbol} ${capitalize(
-    faucetInfo.network,
-  )} Faucet`;
+  $: if (mounted) {
+    document.title = `${faucetInfo.network} Faucet`;
+  }
 
   let widgetID;
   $: if (mounted && hcaptchaLoaded) {
@@ -167,8 +166,10 @@
   {/if}
 </svelte:head>
 
-{#if baseFrontendType}
-  <BaseDesign {faucetInfo} {input} {handleRequest} {gweiToEth} />
-{:else if redesignFrontendType}
-  <Redesign {faucetInfo} {input} {handleRequest} {gweiToEth} />
+{#if mounted}
+  {#if baseFrontendType}
+    <BaseDesign {faucetInfo} {input} {handleRequest} {gweiToEth} />
+  {:else if redesignFrontendType}
+    <Redesign {faucetInfo} {input} {handleRequest} {gweiToEth} />
+  {/if}
 {/if}

--- a/web/src/components/Button.svelte
+++ b/web/src/components/Button.svelte
@@ -21,11 +21,11 @@
     border-width: 0px;
     padding: 12px 24px;
     cursor: pointer;
-     background-color: #8950FA;
+     background-color: var(--primary-color, #8950FA);
   }
 
   .primary {
-    background-color: #8950FA;
+    background-color: var(--primary-color, #8950FA);
   }
 
   .secondary {

--- a/web/src/components/Navigation.svelte
+++ b/web/src/components/Navigation.svelte
@@ -68,14 +68,14 @@
   }
 
   .navbar-item:hover {
-    color: #8950fa !important;
+    color: var(--primary-color, #8950fa) !important;
     background-color: transparent !important;
   }
 
   @media (max-width: 768px) {
     .burger-menu {
       display: block;
-      color: #8950fa;
+      color: var(--primary-color, #8950fa);
     }
 
     .navbar {
@@ -91,7 +91,7 @@
     }
     .navbar-item:hover {
       color: white !important;
-      background-color: rgba(137, 80, 250, 0.5) !important;
+      background-color: var(--primary-color-light, rgba(137, 80, 250, 0.5)) !important;
     }
 
     .navbar.open {

--- a/web/src/components/Redesign.svelte
+++ b/web/src/components/Redesign.svelte
@@ -26,7 +26,7 @@
   }
 </script>
 
-<main>
+<main style="--primary-color: {faucetInfo.primary_color}; --primary-color-light: {faucetInfo.primary_color_light}; --primary-color-dark: {faucetInfo.primary_color_dark};">
   <section
     class="hero is-info is-fullheight"
     style="background-image: url({faucetInfo.background_url})"
@@ -34,21 +34,19 @@
     <div class="hero-head">
       <nav class="navbar">
         <div class="header-container">
-          <div class="navbar-brand">
-            <a class="navbar-item" href="https://gateway.fm/">
-              <span class="icon icon-brand">
-                <img src={faucetInfo.logo_url} alt="logo" />
-              </span>
-            </a>
-            <div class="navbar-desktop">
-              {#if !paidCustomer}
+          {#if !paidCustomer}
+            <div class="navbar-brand">
+              <a class="navbar-item" href="https://gateway.fm/">
+                <span class="icon icon-brand">
+                  <img src={faucetInfo.logo_url} alt="logo" />
+                </span>
+              </a>
+              <div class="navbar-desktop">
                 <Navigation />
-              {/if}
+              </div>
             </div>
-          </div>
-          <div>
-            <div class="navbar-end">
-              {#if !paidCustomer}
+            <div>
+              <div class="navbar-end">
                 <a
                   class="navbar-desktop"
                   href="https://presto.gateway.fm/onboarding"
@@ -63,14 +61,16 @@
                     />
                   </button></a
                 >
-              {/if}
+              </div>
             </div>
-          </div>
-          <div class="navbar-mobile">
-            {#if !paidCustomer}
+            <div class="navbar-mobile">
               <Navigation />
-            {/if}
-          </div>
+            </div>
+          {:else}
+            <div class="logo-centered">
+              <img src={faucetInfo.logo_url} alt="logo" class="logo-large" />
+            </div>
+          {/if}
         </div>
       </nav>
     </div>
@@ -206,12 +206,12 @@
     font-size: 14px;
     font-weight: 500;
     padding: 8px 12px;
-    background-color: #dcf0fd;
+    background-color: var(--primary-color-light);
     border-radius: 8px;
     color: #183053;
   }
   .link {
-    color: #8950fa !important;
+    color: var(--primary-color) !important;
     text-decoration: underline;
     cursor: pointer;
   }
@@ -221,7 +221,7 @@
     justify-content: center;
     align-items: center;
     width: 100%;
-    background-color: #8950fa;
+    background-color: var(--primary-color);
     gap: 16px;
   }
 
@@ -240,7 +240,8 @@
     align-items: center;
     padding: 8px 12px;
     border-radius: 8px;
-    background-color: #eee8ff;
+    background-color: var(--primary-color-light);
+    color: #183053;
   }
   .field {
     display: flex;
@@ -249,7 +250,7 @@
   }
 
   .gas-token {
-    color: #8950fa;
+    color: var(--primary-color-dark);
   }
 
   .card {
@@ -260,25 +261,23 @@
     box-shadow: 0px 8px 16px rgba(0, 0, 0, 0.1);
     border-radius: 19px;
     padding: 32px;
-    color: #161718;
+    color: var(--primary-color-dark);
   }
 
   .title {
     display: inline-flex;
-    color: #161718;
+    color: var(--primary-color) !important;
     gap: 8px;
     font-weight: 500;
     font-size: 72px; /* Adjust size as needed */
     line-height: 80px;
     letter-spacing: 0px;
   }
-  .hero.is-info {
-    background:
-      linear-gradient(rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.2)),
-      no-repeat center center fixed;
-    -webkit-background-size: cover;
-    -moz-background-size: cover;
-    -o-background-size: cover;
+  :global(.hero.is-info) {
+    background-color: transparent !important;
+    background-repeat: no-repeat;
+    background-position: center center;
+    background-attachment: fixed;
     background-size: cover;
   }
 
@@ -289,7 +288,7 @@
     font-size: 14px;
     font-weight: 500;
     letter-spacing: 0px;
-    color: #161718;
+    color: var(--primary-color-dark);
   }
 
   .navbar-mobile {
@@ -313,7 +312,7 @@
   }
 
   .navbar-item {
-    color: #8950fa !important;
+    color: var(--primary-color) !important;
   }
   .navbar-item:hover {
     background-color: transparent !important;
@@ -327,6 +326,17 @@
 
   .icon-brand {
     width: 8rem;
+  }
+
+  .logo-centered {
+    display: flex;
+    justify-content: center;
+    width: 100%;
+  }
+
+  .logo-large {
+    height: 56px;
+    object-fit: contain;
   }
 
   @media (max-width: 992px) {

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -1,6 +1,7 @@
+import { mount } from 'svelte';
 import App from './App.svelte';
 
-const app = new App({
+const app = mount(App, {
   target: document.getElementById('app'),
 });
 


### PR DESCRIPTION
## Summary
- Add `frontend.primaryColor`, `frontend.primaryColorLight`, and `frontend.primaryColorDark` CLI flags for customizing the faucet UI color scheme
- Fix Svelte 5 compatibility (`mount` API in `main.js`)
- Prevent flash of default content on page load (render only after `/api/info` responds)
- Center and properly size logo for paid customers
- Remove gradient overlay from hero background

## New flags

| Flag | Description | Default |
|------|-------------|---------|
| `-frontend.primaryColor` | Primary accent color (buttons, title) | `#8950fa` |
| `-frontend.primaryColorLight` | Light variant (badge backgrounds, amount text) | `#eee8ff` |
| `-frontend.primaryColorDark` | Dark variant (card/subtitle text) | `#161718` |

## Example (Billions Testnet)

```
-frontend.primaryColor="#0046FF" -frontend.primaryColorLight="#D6E4FF" -frontend.primaryColorDark="#001A4D"
```

## Test plan
- [ ] Build Docker image with `--no-cache`
- [ ] Run with default flags and verify existing purple theme is preserved
- [ ] Run with custom color flags and verify all UI elements update correctly
- [ ] Verify no flash of default content on page reload
- [ ] Verify logo is centered for `paidcustomer=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)