### PR TITLE
PRST-2562: Fix Serving from subtitle styling

### DIFF
--- a/web/src/components/Redesign.svelte
+++ b/web/src/components/Redesign.svelte
@@ -283,12 +283,12 @@
 
   .subtitle {
     display: flex;
-    justify-content: space-between;
     align-items: center;
+    gap: 8px;
     font-size: 14px;
     font-weight: 500;
     letter-spacing: 0px;
-    color: var(--primary-color-dark);
+    color: #183053 !important;
   }
 
   .navbar-mobile {


### PR DESCRIPTION
## Summary
- Fix "Serving from" text color to match address badge (`#183053`), overriding Bulma's white color in `.hero.is-info`
- Fix subtitle layout: replace `space-between` with `gap: 8px` to close the gap between label and address

## Test plan
- [ ] Verify "Serving from" text is visible and matches the address badge color
- [ ] Verify subtitle spacing looks correct on desktop and mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)