### PR TITLE
chore: align go.mod directive to 1.25 (Aikido go-EOL)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/chainflag/eth-faucet
 
-go 1.24.0
+go 1.25.0
 
-toolchain go1.24.10
+toolchain go1.25.0
 
 require (
 	github.com/agiledragon/gomonkey/v2 v2.12.0


### PR DESCRIPTION
## Summary

Aligns the `go.mod` directive and `toolchain` from 1.24 to 1.25, matching the builder image (`golang:1.25-alpine`) and CI `go-version: 1.25.0` that already landed on `main`. This clears the remaining trailing piece of the Aikido go-EOL finding.

## Aikido reference

- Linear RD-1015 (go EOL — eth-faucet)
- The Dockerfile builder and all 3 CI `go-version` pins were already bumped to 1.25 on `main`; only the `go.mod` directive + `toolchain` line trailed at 1.24.

## Test plan

- [ ] CI green
- [ ] No dependency changes (directive-only; `go.sum` untouched) — 1.25 build compatibility already proven by green `main` CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
