### PR TITLE
PRST-3808: add per-IP and per-wallet withdrawal limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ The following are the available command-line flags(excluding above wallet flags)
 | -proxycount          | Count of reverse proxies in front of the server   | 0                   |
 | -faucet.amount       | Number of Gwei to transfer per user request       | 1000000000          |
 | -faucet.minutes      | Number of minutes to wait between funding rounds  | 1440                |
+| -faucet.ipwithdrawals | Number of withdrawals allowed per IP within the faucet.minutes window | 1 |
+| -faucet.walletwithdrawals | Number of withdrawals allowed per wallet address within the faucet.minutes window | 1 |
 | -faucet.name         | Network name to display on the frontend           | testnet             |
 | -faucet.symbol       | Token symbol to display on the frontend           | ETH                 |
 | -hcaptcha.sitekey    | hCaptcha sitekey                                  |                     |

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -26,6 +26,8 @@ var (
 
 	payoutFlag            = flag.Int64("faucet.amount", 1000000000, "Number of Gwei to transfer per user request")
 	intervalFlag          = flag.Int("faucet.minutes", 1440, "Number of minutes to wait between funding rounds")
+	ipWithdrawalsFlag     = flag.Int("faucet.ipwithdrawals", 1, "Number of withdrawals allowed per IP within the faucet.minutes window")
+	walletWithdrawalsFlag = flag.Int("faucet.walletwithdrawals", 1, "Number of withdrawals allowed per wallet address within the faucet.minutes window")
 	netnameFlag           = flag.String("faucet.name", "testnet", "Network name to display on the frontend")
 	symbolFlag            = flag.String("faucet.symbol", "ETH", "Token symbol to display on the frontend")
 	logoFlag              = flag.String("frontend.logo", "/gatewayfm-logo.svg", "Logo to display on the frontend")
@@ -83,6 +85,8 @@ func Execute() {
 		*symbolFlag,
 		*httpPortFlag,
 		*intervalFlag,
+		*ipWithdrawalsFlag,
+		*walletWithdrawalsFlag,
 		*proxyCntFlag,
 		*payoutFlag,
 		*hcaptchaSiteKeyFlag,

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -9,6 +9,8 @@ type Config struct {
 	symbol            string
 	httpPort          int
 	interval          int
+	ipWithdrawals     int
+	walletWithdrawals int
 	payout            int64
 	proxyCount        int
 	hcaptchaSiteKey   string
@@ -26,7 +28,7 @@ type Config struct {
 
 func NewConfig(
 	network, symbol string,
-	httpPort, interval, proxyCount int,
+	httpPort, interval, ipWithdrawals, walletWithdrawals, proxyCount int,
 	payout int64,
 	hcaptchaSiteKey, hcaptchaSecret, logoURL, backgroundURL, primaryColor, primaryColorLight, primaryColorDark string,
 	frontendType string,
@@ -39,6 +41,8 @@ func NewConfig(
 		symbol:            symbol,
 		httpPort:          httpPort,
 		interval:          interval,
+		ipWithdrawals:     ipWithdrawals,
+		walletWithdrawals: walletWithdrawals,
 		payout:            payout,
 		proxyCount:        proxyCount,
 		hcaptchaSiteKey:   hcaptchaSiteKey,

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -16,19 +16,29 @@ import (
 )
 
 type Limiter struct {
-	mutex      sync.Mutex
-	cache      *ttlcache.Cache
-	proxyCount int
-	ttl        time.Duration
+	mutex             sync.Mutex
+	cache             *ttlcache.Cache
+	proxyCount        int
+	ttl               time.Duration
+	ipWithdrawals     int
+	walletWithdrawals int
 }
 
-func NewLimiter(proxyCount int, ttl time.Duration) *Limiter {
+func NewLimiter(proxyCount, ipWithdrawals, walletWithdrawals int, ttl time.Duration) *Limiter {
+	if ipWithdrawals < 1 {
+		ipWithdrawals = 1
+	}
+	if walletWithdrawals < 1 {
+		walletWithdrawals = 1
+	}
 	cache := ttlcache.NewCache()
 	cache.SkipTTLExtensionOnHit(true)
 	return &Limiter{
-		cache:      cache,
-		proxyCount: proxyCount,
-		ttl:        ttl,
+		cache:             cache,
+		proxyCount:        proxyCount,
+		ttl:               ttl,
+		ipWithdrawals:     ipWithdrawals,
+		walletWithdrawals: walletWithdrawals,
 	}
 }
 
@@ -51,33 +61,62 @@ func (l *Limiter) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.Ha
 
 	clientIP := getClientIPFromRequest(l.proxyCount, r)
 	l.mutex.Lock()
-	if l.limitByKey(w, address) || l.limitByKey(w, clientIP) {
+	if l.limitByKey(w, address, l.walletWithdrawals) || l.limitByKey(w, clientIP, l.ipWithdrawals) {
 		l.mutex.Unlock()
 		return
 	}
-	l.cache.SetWithTTL(address, true, l.ttl)
-	l.cache.SetWithTTL(clientIP, true, l.ttl)
+	walletCount := l.increment(address)
+	ipCount := l.increment(clientIP)
 	l.mutex.Unlock()
 
 	next.ServeHTTP(w, r)
 	if w.(negroni.ResponseWriter).Status() != http.StatusOK {
-		l.cache.Remove(address)
-		l.cache.Remove(clientIP)
+		l.mutex.Lock()
+		l.decrement(address)
+		l.decrement(clientIP)
+		l.mutex.Unlock()
 		return
 	}
 	log.WithFields(log.Fields{
-		"address":  address,
-		"clientIP": clientIP,
-	}).Info("Maximum request limit has been reached")
+		"address":           address,
+		"clientIP":          clientIP,
+		"walletWithdrawals": fmt.Sprintf("%d/%d", walletCount, l.walletWithdrawals),
+		"ipWithdrawals":     fmt.Sprintf("%d/%d", ipCount, l.ipWithdrawals),
+	}).Info("Faucet withdrawal recorded")
 }
 
-func (l *Limiter) limitByKey(w http.ResponseWriter, key string) bool {
-	if _, ttl, err := l.cache.GetWithTTL(key); err == nil {
+func (l *Limiter) limitByKey(w http.ResponseWriter, key string, limit int) bool {
+	if count, ttl, err := l.cache.GetWithTTL(key); err == nil && count.(int) >= limit {
 		errMsg := fmt.Sprintf("You have exceeded the rate limit. Please wait %s before you try again", ttl.Round(time.Second))
 		renderJSON(w, claimResponse{Message: errMsg}, http.StatusTooManyRequests)
 		return true
 	}
 	return false
+}
+
+// increment bumps the withdrawal count for the key and returns the new count.
+// When the key already exists it reuses the remaining TTL so the window stays
+// anchored at the first claim (the cache is created with SkipTTLExtensionOnHit,
+// so GetWithTTL returns the remaining time until expiry).
+func (l *Limiter) increment(key string) int {
+	if count, ttl, err := l.cache.GetWithTTL(key); err == nil {
+		n := count.(int) + 1
+		l.cache.SetWithTTL(key, n, ttl)
+		return n
+	}
+	l.cache.SetWithTTL(key, 1, l.ttl)
+	return 1
+}
+
+// decrement rolls back a withdrawal count, removing the entry once it reaches zero.
+func (l *Limiter) decrement(key string) {
+	if count, ttl, err := l.cache.GetWithTTL(key); err == nil {
+		if c := count.(int); c > 1 {
+			l.cache.SetWithTTL(key, c-1, ttl)
+		} else {
+			l.cache.Remove(key)
+		}
+	}
 }
 
 func getClientIPFromRequest(proxyCount int, r *http.Request) string {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -32,7 +32,7 @@ func NewServer(builder chain.TxBuilder, cfg *Config) *Server {
 func (s *Server) setupRouter() *http.ServeMux {
 	router := http.NewServeMux()
 	router.Handle("/", http.FileServer(web.Dist()))
-	limiter := NewLimiter(s.cfg.proxyCount, time.Duration(s.cfg.interval)*time.Minute)
+	limiter := NewLimiter(s.cfg.proxyCount, s.cfg.ipWithdrawals, s.cfg.walletWithdrawals, time.Duration(s.cfg.interval)*time.Minute)
 	hcaptcha := NewCaptcha(s.cfg.hcaptchaSiteKey, s.cfg.hcaptchaSecret)
 	router.Handle("/api/claim", negroni.New(limiter, hcaptcha, negroni.Wrap(s.handleClaim())))
 	router.Handle("/api/info", s.handleInfo())

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -9,9 +9,11 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/mock"
+	"github.com/urfave/negroni/v3"
 
 	"github.com/chainflag/eth-faucet/internal/chain"
 )
@@ -71,6 +73,78 @@ func TestHandleClaim(t *testing.T) {
 
 	mockBuilder.AssertExpectations(t)
 
+}
+
+// testAddress returns a valid EIP-55 checksummed address derived from n.
+func testAddress(n int) string {
+	return common.HexToAddress(fmt.Sprintf("0x%040x", n)).Hex()
+}
+
+// claim drives a single request through the limiter middleware as if it came
+// from clientIP. nextStatus is the status the downstream handler responds with
+// when the limiter lets the request through. It returns the final status code.
+func claim(limiter *Limiter, address, clientIP string, nextStatus int) int {
+	reqBody := strings.NewReader(fmt.Sprintf(`{"address": "%s"}`, address))
+	req := httptest.NewRequest("POST", "/api/claim", reqBody)
+	req.RemoteAddr = clientIP + ":12345"
+
+	rr := httptest.NewRecorder()
+	rw := negroni.NewResponseWriter(rr)
+	limiter.ServeHTTP(rw, req, func(w http.ResponseWriter, r *http.Request) {
+		renderJSON(w, claimResponse{Message: "ok"}, nextStatus)
+	})
+	return rw.Status()
+}
+
+func TestLimiterWalletAndIPWithdrawals(t *testing.T) {
+	// 1 claim per wallet, 5 claims per IP, within an active window.
+	limiter := NewLimiter(0, 5, 1, time.Hour)
+	const ip = "10.0.0.1"
+
+	// Five distinct wallets from the same IP all succeed.
+	for i := 1; i <= 5; i++ {
+		if code := claim(limiter, testAddress(i), ip, http.StatusOK); code != http.StatusOK {
+			t.Fatalf("wallet %d: expected %d, got %d", i, http.StatusOK, code)
+		}
+	}
+
+	// Sixth distinct wallet from the same IP is blocked by the IP limit.
+	if code := claim(limiter, testAddress(6), ip, http.StatusOK); code != http.StatusTooManyRequests {
+		t.Errorf("6th wallet: expected %d, got %d", http.StatusTooManyRequests, code)
+	}
+
+	// A fresh IP, but reusing wallet #1, is blocked by the per-wallet limit of 1.
+	if code := claim(limiter, testAddress(1), "10.0.0.2", http.StatusOK); code != http.StatusTooManyRequests {
+		t.Errorf("repeat wallet: expected %d, got %d", http.StatusTooManyRequests, code)
+	}
+}
+
+func TestLimiterSingleWithdrawalRegression(t *testing.T) {
+	// Defaults (1/1) preserve the original single-claim-per-window behavior.
+	limiter := NewLimiter(0, 1, 1, time.Hour)
+	const ip = "10.0.0.1"
+
+	if code := claim(limiter, testAddress(1), ip, http.StatusOK); code != http.StatusOK {
+		t.Fatalf("first claim: expected %d, got %d", http.StatusOK, code)
+	}
+	if code := claim(limiter, testAddress(2), ip, http.StatusOK); code != http.StatusTooManyRequests {
+		t.Errorf("second claim same IP: expected %d, got %d", http.StatusTooManyRequests, code)
+	}
+}
+
+func TestLimiterRollbackOnFailure(t *testing.T) {
+	// A failed downstream response must not consume the window slot.
+	limiter := NewLimiter(0, 1, 1, time.Hour)
+	const ip = "10.0.0.1"
+	addr := testAddress(1)
+
+	if code := claim(limiter, addr, ip, http.StatusInternalServerError); code != http.StatusInternalServerError {
+		t.Fatalf("failed claim: expected %d, got %d", http.StatusInternalServerError, code)
+	}
+	// The count was rolled back, so a retry is allowed.
+	if code := claim(limiter, addr, ip, http.StatusOK); code != http.StatusOK {
+		t.Errorf("retry after failure: expected %d, got %d", http.StatusOK, code)
+	}
 }
 
 func TestHandleInfo(t *testing.T) {


### PR DESCRIPTION
## Context

Closes [PRST-3808](https://linear.app/gateway-fm/issue/PRST-3808/faucet-add-faucetwithdrawals-parameter).

The faucet previously allowed exactly **one** withdrawal per wallet address and per client IP within the `-faucet.minutes` window. T-REX wants their community to be able to fund **multiple** wallets (e.g. 5) within that 24h window.

## Changes

Replaces the binary "seen / not seen" rate-limit check with a **counter**, exposed via two new flags (both default to `1`, so existing deployments are unchanged):

| Flag | Description | Default |
|------|-------------|---------|
| `-faucet.ipwithdrawals` | Max claims per client IP within the `faucet.minutes` window | 1 |
| `-faucet.walletwithdrawals` | Max claims per wallet address within the window | 1 |

T-REX's "5 wallets / 24h, no repeats" → `-faucet.ipwithdrawals=5 -faucet.walletwithdrawals=1`.

Implementation notes:
- The window stays **anchored at the first claim**: `increment` reuses the remaining TTL (the cache uses `SkipTTLExtensionOnHit`), so later claims don't slide the window forward.
- Failed downstream responses roll the count back (decrement) instead of consuming a slot.
- Fixed a pre-existing misleading success log (`"Maximum request limit has been reached"`) — it now logs `"Faucet withdrawal recorded"` with usage counts (e.g. `ipWithdrawals=3/5`).

## Tests

Added limiter unit tests in `internal/server/server_test.go`: per-IP + per-wallet limits, single-claim regression, and failure-rollback. `go build`, `go vet`, and `go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)