### PR TITLE
PRST-3817: push Docker image on non-PR builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: ${{ env.PUSH_TO_REGISTRY == 'true' }}
+          push: ${{ github.event_name != 'pull_request' }}
           pull: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Problem

The `Docker` workflow builds the image but never pushes it. The push step was gated on:

```yaml
push: ${{ env.PUSH_TO_REGISTRY == 'true' }}
```

`PUSH_TO_REGISTRY` is never defined anywhere (no `env:` block sets it, and the `env.` context does not read repository `vars`/`secrets`), so the expression always evaluated to `false` → `push: false` on **every** event, including tag and `main` pushes.

Confirmed in the `v0.1.19` Docker run ([27398328111](https://github.com/gateway-fm/eth-faucet/actions/runs/27398328111)):
```
push: false
WARNING: No output specified ... Build result will only remain in the build cache.
```
So every tagged release so far produced **no published image** (goreleaser binaries were unaffected).

## Fix

```diff
-          push: ${{ env.PUSH_TO_REGISTRY == 'true' }}
+          push: ${{ github.event_name != 'pull_request' }}
```

Standard build-push-action pattern: PRs validate build-only, while `push`/tag/`workflow_dispatch` events push. DockerHub login already uses `secrets.DOCKERHUB_USERNAME` / `secrets.DOCKERHUB_TOKEN`; no new actions added (all remain SHA-pinned).

## Follow-up after merge

A new release tag (`v0.1.20`) will be cut, which includes this fix plus the recently merged #48. That tagged build will publish the Docker image automatically — no need to republish `v0.1.19`.

Ticket: PRST-3817

🤖 Generated with [Claude Code](https://claude.com/claude-code)