### PR TITLE
PRST-3831: stop pushing moving :latest Docker tag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,6 +20,10 @@ jobs:
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: gatewayfm/eth-faucet-generic
+          # DockerHub repo has tag immutability enabled, so a moving `latest`
+          # tag cannot be updated. Only publish immutable version tags.
+          flavor: |
+            latest=false
 
       - name: Login to DockerHub
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3


### PR DESCRIPTION
## Problem

After PRST-3817 fixed the Docker workflow to actually push, the `v0.1.20` tagged build pushed `gatewayfm/eth-faucet-generic:v0.1.20` successfully but **failed** on `:latest` ([run 27401418468](https://github.com/gateway-fm/eth-faucet/actions/runs/27401418468)):

```
ERROR: failed to push .../eth-faucet-generic:latest: denied: ... tag latest is already
assigned to an image in this repository and cannot be updated due to immutability settings.
```

The DockerHub repo has **tag immutability** enabled, which is incompatible with the moving `:latest` tag that `docker/metadata-action` emits by default.

## Fix

```diff
         with:
           images: gatewayfm/eth-faucet-generic
+          flavor: |
+            latest=false
```

Only immutable version tags (e.g. `:v0.1.20`) are published; consumers pin to a version, consistent with the immutability policy.

## Notes

- The `v0.1.20` image is **already published** — this only fixes the red workflow status and future tagged builds. No re-tag needed.
- No new actions added; all remain SHA-pinned.

Ticket: PRST-3831

🤖 Generated with [Claude Code](https://claude.com/claude-code)