### PR TITLE
PRST-3866: upgrade openssl (eth-faucet-generic)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,10 @@ RUN go build -o eth-faucet -ldflags "-s -w"
 
 FROM alpine:3.22
 
-RUN apk add --no-cache ca-certificates
+# PRST-3866: patch openssl libs (libssl3/libcrypto3) for CVE-2026-45447
+# (PKCS#7/S-MIME use-after-free), 3.5.6-r0 -> 3.5.7-r0. Scoped upgrade only;
+# no blanket `apk upgrade`.
+RUN apk add --no-cache --upgrade ca-certificates libssl3 libcrypto3
 
 COPY --from=backend /backend-build/eth-faucet /app/eth-faucet
 


### PR DESCRIPTION
Resolves the Aikido openssl finding on the `gatewayfm/eth-faucet-generic` container (built from this repo).

| Ticket | Pri | Fix |
|---|---|---|
| [PRST-3866](https://linear.app/gateway-fm/issue/PRST-3866) | High | `libssl3`/`libcrypto3` 3.5.6-r0 → 3.5.7-r0 (CVE-2026-45447, PKCS#7/S-MIME use-after-free) |

Added a scoped `--upgrade ca-certificates libssl3 libcrypto3` to the `alpine:3.22` runtime stage's existing `apk add`. No blanket `apk upgrade`.

**Verified:** `alpine:3.22 + apk add --upgrade libssl3 libcrypto3` resolves to `libssl3`/`libcrypto3` `3.5.7-r0`. Aikido scan clean (only pre-existing out-of-scope "runs as root").

🤖 Generated with [Claude Code](https://claude.com/claude-code)